### PR TITLE
[feat]: kakao login 구현 & develop CI/CD 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,14 +3,14 @@ name: Deploy to Amazon EC2
 on:
   push:
     branches:
-      - main
+      - develop
 
 env:
   AWS_REGION: ap-northeast-2
   PROJECT_NAME: ptip2.0
-  S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-  CODE_DEPLOY_APPLICATION_NAME: spring-boot-app
-  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: spring-boot-deploy-group
+  S3_BUCKET_NAME: ${{ secrets.TEST_S3_BUCKET_NAME }}
+  CODE_DEPLOY_APPLICATION_NAME: testptip-codedeploy-application
+  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: testptip-codedeploy-deployment-group
 
 permissions:
   contents: read
@@ -31,7 +31,7 @@ jobs:
 
       - name: Generate .env and application-prod.properties
         run: |
-          echo "${{ secrets.ENV_FILE }}" > .env
+          echo "${{ secrets.TEST_ENV_FILE }}" > .env
           chmod +x ./generate-properties.sh
           ./generate-properties.sh
 
@@ -44,8 +44,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Prepare deployment bundle

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-#      - name: Generate .env and application.properties
-#        run: |
-#          echo "${{ secrets.ENV_FILE }}" > .env
-#          chmod +x ./generate-properties.sh
-#          ./generate-properties.sh
+      - name: Generate .env and application-prod.properties
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > .env
+          chmod +x ./generate-properties.sh
+          ./generate-properties.sh
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
@@ -48,13 +48,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Prepare deployment bundle
+        run: |
+          mkdir -p deploy/scripts
+          cp build/libs/*.jar deploy/
+          cp appspec.yml deploy/
+          cp src/main/resources/application-prod.properties deploy/
+          cp scripts/*.sh deploy/scripts/
+          chmod +x deploy/scripts/*.sh
+
       - name: Upload to AWS S3
         run: |
           aws deploy push \
             --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
             --ignore-hidden-files \
             --s3-location s3://$S3_BUCKET_NAME/$GITHUB_SHA.zip \
-            --source .
+            --source ./deploy
 
       - name: Deploy to AWS EC2 from S3
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/application.properties
+src/main/resources/application-prod.properties
 
 ### STS ###
 .apt_generated
@@ -36,3 +37,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# dotenv environment variable files
+.env

--- a/appspec.yml
+++ b/appspec.yml
@@ -4,7 +4,7 @@ os: linux
 #배포 파일 설정
 files:
   - source: /
-    destination: /home/ubuntu/ptip2.0_backend
+    destination: /home/ubuntu/server
     overwrite: yes
 
 #이미 있을 경우 덮어쓰기

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 //    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-//    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,19 @@ repositories {
 }
 
 dependencies {
-//    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/generate-properties.sh
+++ b/generate-properties.sh
@@ -21,15 +21,20 @@ spring.datasource.password=$SPRING_DATASOURCE_PASSWORD
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-#jwt.secret=$JWT_SECRET
-#jwt.expiration=$JWT_EXPIRATION
-#
-#springdoc.swagger-ui.path=$SPRINGDOC_SWAGGER_UI_PATH
-#springdoc.api-docs.path=$SPRINGDOC_API_DOCS_PATH
-#springdoc.default-consumes-media-type=application/json
-#springdoc.default-produces-media-type=application/json
-#springdoc.swagger-ui.enabled=true
-#springdoc.swagger-ui.disable-swagger-default-url=true
+jwt.secret=$JWT_SECRET
+jwt.access-token-expiration=$JWT_ACCESS_TOKEN_EXPIRATION
+jwt.refresh-token-expiration=$JWT_REFRESH_TOKEN_EXPIRATION
+
+kakao.client-id=$KAKAO_CLIENT_ID
+kakao.client-secret=$KAKAO_CLIENT_SECRET
+kakao.redirect-uri=$KAKAO_REDIRECT_URI
+
+springdoc.swagger-ui.path=$SPRINGDOC_SWAGGER_UI_PATH
+springdoc.api-docs.path=$SPRINGDOC_API_DOCS_PATH
+springdoc.default-consumes-media-type=application/json
+springdoc.default-produces-media-type=application/json
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.disable-swagger-default-url=true
 EOF
 
 echo "✅ application-prod.properties 생성 완료!"

--- a/generate-properties.sh
+++ b/generate-properties.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "📦 Generating application.properties from .env..."
+
+# .env 파일 불러오기
+set -a
+source .env
+set +a
+
+mkdir -p src/main/resources
+
+cat <<EOF > src/main/resources/application-prod.properties
+spring.application.name=ptip2.0_backend
+spring.jackson.time-zone=Asia/Seoul
+
+server.port=$SERVER_PORT
+
+spring.datasource.url=$SPRING_DATASOURCE_URL
+spring.datasource.username=$SPRING_DATASOURCE_USERNAME
+spring.datasource.password=$SPRING_DATASOURCE_PASSWORD
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+#jwt.secret=$JWT_SECRET
+#jwt.expiration=$JWT_EXPIRATION
+#
+#springdoc.swagger-ui.path=$SPRINGDOC_SWAGGER_UI_PATH
+#springdoc.api-docs.path=$SPRINGDOC_API_DOCS_PATH
+#springdoc.default-consumes-media-type=application/json
+#springdoc.default-produces-media-type=application/json
+#springdoc.swagger-ui.enabled=true
+#springdoc.swagger-ui.disable-swagger-default-url=true
+EOF
+
+echo "✅ application-prod.properties 생성 완료!"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # 프로젝트 경로
-PROJECT_ROOT="/home/ubuntu/ptip2.0_backend"
+PROJECT_ROOT="/home/ubuntu/server"
 OLD_DIR="$PROJECT_ROOT/old"
 DEPLOY_LOG="$PROJECT_ROOT/deploy.log"
 TIME_NOW=$(date +%c)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,38 +1,23 @@
 #!/usr/bin/env bash
 
-PROJECT_ROOT="/home/ubuntu/ptip2.0_backend"
-JAR_SOURCE=$(ls $PROJECT_ROOT/build/libs/*.jar | tail -n 1)
-JAR_TARGET="$PROJECT_ROOT/spring-webapp.jar"
-
-APP_LOG="$PROJECT_ROOT/app.log"
-ERROR_LOG="$PROJECT_ROOT/error.log"
-DEPLOY_LOG="$PROJECT_ROOT/deploy.log"
+DEPLOY_LOG="/home/ubuntu/server/deploy.log"
 TIME_NOW=$(date +%c)
-PORT=8080
+JAR_SOURCE=$(ls /home/ubuntu/server/*.jar | tail -n 1)
+JAR_TARGET="/home/ubuntu/server/spring-webapp.jar"
 
-echo "$TIME_NOW > 새 애플리케이션 배포 시작" >> $DEPLOY_LOG
+echo "$TIME_NOW > 현재 Nginx 상태:" >> $DEPLOY_LOG
+sudo systemctl status nginx >> $DEPLOY_LOG
+
+echo "$TIME_NOW > 새 애플리케이션 복사 시작" >> $DEPLOY_LOG
 
 if [ ! -f "$JAR_SOURCE" ]; then
   echo "$TIME_NOW > JAR 파일이 존재하지 않아 복사 실패!" >> $DEPLOY_LOG
   exit 1
 fi
 
-echo "$TIME_NOW > JAR 복사: $JAR_SOURCE -> $JAR_TARGET" >> $DEPLOY_LOG
 cp "$JAR_SOURCE" "$JAR_TARGET"
-
 chmod +x "$JAR_TARGET"
-echo "$TIME_NOW > 실행 권한 부여 및 애플리케이션 실행" >> $DEPLOY_LOG
+echo "$TIME_NOW > JAR 복사 및 권한 부여 완료" >> $DEPLOY_LOG
 
-# 백그라운드 실행
-sudo nohup java -Duser.timezone=Asia/Seoul -jar "$JAR_TARGET" > "$APP_LOG" 2> "$ERROR_LOG" &
-
-sleep 5
-
-# 포트 점유 상태 확인
-if sudo lsof -i :$PORT -sTCP:LISTEN > /dev/null; then
-  echo "$TIME_NOW > 포트 $PORT 정상적으로 점유됨. 실행 성공 추정" >> $DEPLOY_LOG
-  sudo lsof -i :$PORT -sTCP:LISTEN >> $DEPLOY_LOG
-else
-  echo "$TIME_NOW > 포트 $PORT 점유 안됨. 실행 실패 가능성 있음" >> $DEPLOY_LOG
-  tail -n 20 "$ERROR_LOG" >> $DEPLOY_LOG
-fi
+echo "$TIME_NOW > springboot-app 서비스 재시작" >> $DEPLOY_LOG
+sudo systemctl restart springboot-app

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,24 +1,14 @@
 #!/usr/bin/env bash
 
-PROJECT_ROOT="/home/ubuntu/ptip2.0_backend"
-DEPLOY_LOG="$PROJECT_ROOT/deploy.log"
+DEPLOY_LOG="/home/ubuntu/server/deploy.log"
 TIME_NOW=$(date +%c)
-PORT=8080
 
-echo "$TIME_NOW > 실행 중인 애플리케이션 종료 시도" >> $DEPLOY_LOG
+echo "$TIME_NOW > springboot-app 서비스 종료 시도" >> $DEPLOY_LOG
 
-# 443 포트 LISTEN 중인 PID 탐색
-CURRENT_PID=$(sudo lsof -i :$PORT -sTCP:LISTEN -t)
+sudo systemctl stop springboot-app
 
-if [ -z "$CURRENT_PID" ]; then
-  echo "$TIME_NOW > 포트 $PORT LISTEN 중인 프로세스 없음" >> $DEPLOY_LOG
+if systemctl is-active --quiet springboot-app; then
+  echo "$TIME_NOW > 종료 실패, 강제 종료 시도 필요" >> $DEPLOY_LOG
 else
-  echo "$TIME_NOW > 포트 $PORT LISTEN 중인 PID $CURRENT_PID 종료 시도" >> $DEPLOY_LOG
-  sudo kill -15 "$CURRENT_PID"
-  sleep 3
-
-  if ps -p "$CURRENT_PID" > /dev/null; then
-    echo "$TIME_NOW > 정상 종료 실패, 강제 종료 시도" >> $DEPLOY_LOG
-    sudo kill -9 "$CURRENT_PID"
-  fi
+  echo "$TIME_NOW > springboot-app 서비스 정상 종료됨" >> $DEPLOY_LOG
 fi

--- a/src/main/java/com/ptip/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ptip/auth/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.ptip.auth.config;
+
+import com.ptip.auth.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/auth/**", "/api-docs/**", "/swagger", "/swagger-ui/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    protected CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.addAllowedOrigin("http://localhost:5173");
+        corsConfiguration.addAllowedOrigin("https://ptutip.p-e.kr");
+        corsConfiguration.addAllowedMethod("*");
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/ptip/auth/config/SwaggerConfig.java
+++ b/src/main/java/com/ptip/auth/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.ptip.auth.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("P-Tip API Documentation")
+                        .description("P-Tip 프로젝트의 API 문서")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("accessToken")) // ✅ 자동 헤더 입력 창 추가
+                .components(
+                        new Components()
+                                // accessToken이라는 스키마 만들어주기
+                                .addSecuritySchemes("accessToken", new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .bearerFormat("JWT")
+                                )
+                                // refreshToken이라는 스키마 만들어주기
+                                .addSecuritySchemes("refreshToken", new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .bearerFormat("JWT")
+                                )
+                );
+    }
+}

--- a/src/main/java/com/ptip/auth/controller/AuthController.java
+++ b/src/main/java/com/ptip/auth/controller/AuthController.java
@@ -1,0 +1,74 @@
+package com.ptip.auth.controller;
+
+import com.ptip.auth.dto.LogoutRequestDto;
+import com.ptip.auth.dto.RefreshTokenRequestDto;
+import com.ptip.auth.entity.User;
+import com.ptip.auth.jwt.JwtUtil;
+import com.ptip.auth.repository.UserRepository;
+import com.ptip.auth.service.KakaoAuthService;
+import com.ptip.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "로그인", description = "카카오 로그인")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtUtil jwtUtil;
+    private final KakaoAuthService kakaoAuthService;
+    private final UserRepository userRepository;
+
+    @Operation(summary = "카카오 로그인 콜백", description = "프론트에서 인가코드(code)로 호출")
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<?> kakaoCallback (@RequestParam String code) throws Exception {
+        // code로 카카오 토큰 → 사용자 정보 → DB 저장 → JWT 발급
+        String accessToken = kakaoAuthService.kakaoLogin(code);
+        return ApiResponse.success(accessToken);
+    }
+
+    @Operation(summary = "로그아웃", description = "email + refreshToken을 바디로 넘겨서 로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestBody LogoutRequestDto request) {
+        String email = request.getEmail();
+
+        // 이메일로 사용자 조회 후 refreshToken 제거
+        userRepository.findAll().stream()
+                .filter(u -> email.equals(u.getEmail()))
+                .findFirst()
+                .ifPresent(user -> {
+                    user.setRefreshToken(null);
+                    userRepository.save(user);
+                });
+
+        return ApiResponse.success("로그아웃 되었습니다.");
+    }
+
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 새로운 액세스 토큰 발급")
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestBody RefreshTokenRequestDto request) {
+        String email = request.getEmail();
+        String rawRefreshToken = request.getRefreshToken().replace("Bearer ", "");
+
+        // 이메일로 사용자 조회
+        Optional<User> optionalUser = userRepository.findAll().stream()
+                .filter(u -> email.equals(u.getEmail()))
+                .findFirst();
+
+        // refreshToken 일치 시 AccessToken 재발급
+        if (optionalUser.isPresent() && rawRefreshToken.equals(optionalUser.get().getRefreshToken())) {
+            String newAccessToken = jwtUtil.createAccessToken(String.valueOf(optionalUser.get().getId()));
+            return ApiResponse.success(newAccessToken);
+        }
+
+        return ApiResponse.error(HttpStatus.UNAUTHORIZED, "Invalid refresh token or user not found");
+    }
+
+}

--- a/src/main/java/com/ptip/auth/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/ptip/auth/dto/KakaoUserInfoDto.java
@@ -1,0 +1,16 @@
+package com.ptip.auth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoUserInfoDto {
+    private String kakaoId;
+    private String nickname;
+    private String email;
+    private String img;
+}
+

--- a/src/main/java/com/ptip/auth/dto/LogoutRequestDto.java
+++ b/src/main/java/com/ptip/auth/dto/LogoutRequestDto.java
@@ -1,0 +1,10 @@
+package com.ptip.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LogoutRequestDto {
+    private String email;  // 사용자 식별
+}

--- a/src/main/java/com/ptip/auth/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/ptip/auth/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,11 @@
+package com.ptip.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RefreshTokenRequestDto {
+    private String email;         // 사용자 이메일
+    private String refreshToken;  // Bearer 포함 가능
+}

--- a/src/main/java/com/ptip/auth/entity/User.java
+++ b/src/main/java/com/ptip/auth/entity/User.java
@@ -1,0 +1,31 @@
+package com.ptip.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(unique = true, nullable = false)
+    private String kakaoId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String img;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/ptip/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ptip/auth/jwt/JwtFilter.java
@@ -1,0 +1,63 @@
+package com.ptip.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    /**
+     * 모든 요청에서 Authorization 헤더에 Bearer 토큰이 있는지 확인 후
+     * 유효한 JWT인지 검증
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        // 토큰이 존재하고 유효하면 (필요시 SecurityContext 설정 가능)
+        if (token != null && validateToken(token)) {
+            // 예: userId 추출, SecurityContext 등록 등
+        }
+
+        // 다음 필터로 계속 진행
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 추출
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7); // "Bearer " 제거
+        }
+        return null;
+    }
+
+    /**
+     * JWT 서명 및 만료 검증
+     */
+    private boolean validateToken(String token) {
+        try {
+            JWT.require(Algorithm.HMAC256(secret)).build().verify(token);
+            return true;
+        } catch (JWTVerificationException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/ptip/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/ptip/auth/jwt/JwtUtil.java
@@ -1,0 +1,42 @@
+package com.ptip.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    /**
+     * AccessToken 생성 (사용자 식별용 ID 포함)
+     */
+    public String createAccessToken(String userId) {
+        return JWT.create()
+                .withSubject("AccessToken")
+                .withClaim("userId", userId)
+                .withExpiresAt(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .sign(Algorithm.HMAC256(secretKey));
+    }
+
+    /**
+     * RefreshToken 생성 (userId 없음, 서버에서 DB로 매칭)
+     */
+    public String createRefreshToken() {
+        return JWT.create()
+                .withSubject("RefreshToken")
+                .withExpiresAt(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .sign(Algorithm.HMAC256(secretKey));
+    }
+}

--- a/src/main/java/com/ptip/auth/repository/UserRepository.java
+++ b/src/main/java/com/ptip/auth/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.ptip.auth.repository;
+
+import com.ptip.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/ptip/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/ptip/auth/service/KakaoAuthService.java
@@ -1,0 +1,121 @@
+package com.ptip.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ptip.auth.dto.KakaoUserInfoDto;
+import com.ptip.auth.entity.User;
+import com.ptip.auth.jwt.JwtUtil;
+import com.ptip.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.*;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    /**
+     * 인가코드(code)를 받아 카카오 access token을 발급받고,
+     * 사용자 정보를 가져와 DB에 저장하거나 업데이트 후
+     * JWT AccessToken을 발급한다.
+     */
+    public String kakaoLogin(String code) throws Exception {
+        String accessToken = getKakaoAccessToken(code);     // 카카오 토큰 요청
+        KakaoUserInfoDto kakaoUser = getUserInfo(accessToken); // 사용자 정보 요청
+
+        // 기존 유저 확인
+        Optional<User> optionalUser = userRepository.findByKakaoId(kakaoUser.getKakaoId());
+
+        // 새 RefreshToken 발급
+        String refreshToken = jwtUtil.createRefreshToken();
+
+        // 기존 유저는 refreshToken만 갱신, 없으면 새로 저장
+        User user = optionalUser.map(u -> {
+            u.setRefreshToken(refreshToken);
+            return u;
+        }).orElseGet(() -> User.builder()
+                .kakaoId(kakaoUser.getKakaoId())
+                .nickname(kakaoUser.getNickname())
+                .email(kakaoUser.getEmail())
+                .img(kakaoUser.getImg())
+                .refreshToken(refreshToken)
+                .build());
+
+        userRepository.save(user); // 저장 또는 갱신
+        return jwtUtil.createAccessToken(String.valueOf(user.getId()));
+    }
+
+    /**
+     * 카카오에 POST 요청을 보내 access token을 발급받는다.
+     */
+    private String getKakaoAccessToken(String code) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+
+        // Client Secret 포함
+        String body = "grant_type=authorization_code"
+                + "&client_id=" + clientId
+                + "&client_secret=" + clientSecret
+                + "&redirect_uri=" + redirectUri
+                + "&code=" + code;
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://kauth.kakao.com/oauth/token"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // 응답 확인 (디버깅 목적)
+        System.out.println("카카오 토큰 응답: " + response.body());
+
+        JsonNode json = objectMapper.readTree(response.body());
+
+        JsonNode accessTokenNode = json.get("access_token");
+        if (accessTokenNode == null) {
+            throw new RuntimeException("카카오 토큰 발급 실패: " + response.body());
+        }
+
+        return accessTokenNode.asText();
+    }
+
+    /**
+     * 발급받은 카카오 access token을 통해 사용자 정보를 가져온다.
+     */
+    private KakaoUserInfoDto getUserInfo(String accessToken) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://kapi.kakao.com/v2/user/me"))
+                .header("Authorization", "Bearer " + accessToken)
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        JsonNode json = objectMapper.readTree(response.body());
+
+        // 사용자 정보 파싱
+        String id = json.get("id").asText();
+        String nickname = json.get("properties").get("nickname").asText();
+        String img = json.get("properties").get("profile_image").asText();
+        String email = json.get("kakao_account").get("email").asText();
+
+        return new KakaoUserInfoDto(id, nickname, email, img);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

카카오 로그인 기능을 구현하고, JWT 기반 인증 구조를 구축했습니다.  
또한 해당 기능을 배포할 수 있도록 develop 브랜치 기준에 맞게 GitHub Actions의 `deploy.yml`을 수정하고, Swagger 문서 UI를 연동했습니다.

---

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CI/CD 설정 수정 (GitHub Actions)
- [x] Swagger 문서 UI 추가
- [x] 주석 추가 및 수정
- [x] 코드 리팩토링 (JWT/응답 구조 통일)

### 🔑 주요 구현 기능

#### ✅ 1. 카카오 로그인 + JWT 인증 구현
- 카카오 인가코드(code)로 access token 요청
- access token으로 사용자 정보 조회
- 사용자 정보 DB 저장 (`nickname`, `email`, `img`, `kakao_id`, `refreshToken`)
- 자체 JWT (access / refresh) 발급 및 응답
- refreshToken 기반 재발급 API, 로그아웃 API 구현

#### ✅ 2. Spring Security + JWT 필터 설정
- `JwtFilter` 추가, `SecurityConfig`에 `/auth/**` 허용
- 추후 인증 연동을 위한 구조 설계

#### ✅ 3. Swagger 연동
- `springdoc-openapi-starter-webmvc-ui` 의존성 추가
- `/swagger-ui/index.html` 경로로 API 테스트 가능
- 모든 컨트롤러 응답을 `ApiResponse<T>`로 통일하여 Swagger 출력 형식 일관

#### ✅ 4. CI/CD 환경 설정
- `develop` 브랜치용 GitHub Actions `deploy.yml` 수정
  - S3 업로드 경로 분리
  - EC2 배포 대상 분기 분리
  - develop 환경 전용 `.properties` 사용 가능하도록 분기 처리

---

## 💬 공유사항 to 리뷰어

- 카카오 로그인 요청은 프론트에서 인가 코드(code)를 받아 `/auth/kakao/callback?code=` 형태로 백엔드에 넘겨주는 방식입니다.
- `ApiResponse<T>` 응답 구조를 전체 통일했으며, Swagger에서도 일관된 포맷으로 확인 가능합니다.
- 추후 사용자를 인증정보로 가져오려면 JWT에서 userId를 파싱하여 `SecurityContext`에 등록하는 구조로 확장 가능합니다.
- `KakaoAuthService`, `JwtFilter`, `JwtUtil`, `AuthController`, `TokenController` 중심으로 살펴봐 주세요.

---

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 기능 동작 확인 및 테스트를 완료했습니다.
- [x] Swagger 문서에서 API 테스트가 가능함을 확인했습니다.
