### PR TITLE
[feat]: 장학금/교내외 프로그램 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ptip/auth/config/QuerydslConfig.java
+++ b/src/main/java/com/ptip/auth/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.ptip.auth.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/ptip/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ptip/auth/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/auth/**", "/api-docs/**", "/swagger", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/", "/auth/**", "/api-docs/**", "/swagger", "/swagger-ui/**", "/api/programs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ptip/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ptip/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.ptip.common.exception;
 
 import com.ptip.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/ptip/program/controller/ProgramController.java
+++ b/src/main/java/com/ptip/program/controller/ProgramController.java
@@ -39,18 +39,18 @@ public class ProgramController {
     public ResponseEntity<ApiResponse<PageResponseDto<ScholarshipResponseDto>>> getScholarshipList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "deadline") String sort,
+            @RequestParam(defaultValue = "마감일순") String sort,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String amount,
             @RequestParam(required = false) String status,
-            @RequestParam(required = false) int limit
+            @RequestParam(defaultValue = "4") int limit
     ) {
         PageResponseDto<ScholarshipResponseDto> response = scholarshipService.findScholarships(page, size, sort, keyword, amount, status, limit);
         return ApiResponse.success(response);
     }
 
     @Operation(summary = "단일 교내외 프로그램 조회", description = "클라이언트가 조회할 데이터를 {id}로 구분해서 요청해주면 해당 id의 교내외 프로그램을 반환합니다.")
-    @GetMapping("/{id}")
+    @GetMapping("/general/{id}")
     public ResponseEntity<ApiResponse<ProgramResponseDto>> getProgram(@PathVariable int id) {
         return ApiResponse.success(programService.findProgram(id));
     }
@@ -63,7 +63,7 @@ public class ProgramController {
     public ResponseEntity<ApiResponse<PageResponseDto<ProgramResponseDto>>> getProgramList(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "applicationEnd") String sort,
+            @RequestParam(defaultValue = "마감임박순") String sort,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) List<String> category,
             @RequestParam(required = false) List<String> mode,

--- a/src/main/java/com/ptip/program/controller/ProgramController.java
+++ b/src/main/java/com/ptip/program/controller/ProgramController.java
@@ -1,0 +1,76 @@
+package com.ptip.program.controller;
+
+import com.ptip.common.dto.ApiResponse;
+import com.ptip.program.dto.PageResponseDto;
+import com.ptip.program.dto.ProgramResponseDto;
+import com.ptip.program.dto.ScholarshipResponseDto;
+import com.ptip.program.service.ProgramService;
+import com.ptip.program.service.ScholarshipService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/programs")
+@Tag(name = "장학금 및 교내외 프로그램", description = "장학금 및 교내외 프로그램 조회 API")
+public class ProgramController {
+
+    private final ScholarshipService scholarshipService;
+    private final ProgramService programService;
+
+    public ProgramController(ScholarshipService scholarshipService, ProgramService programService) {
+        this.scholarshipService = scholarshipService;
+        this.programService = programService;
+    }
+
+    @Operation(summary = "단일 장학금 프로그램 조회", description = "클라이언트가 조회할 데이터를 {id}로 구분해서 요청해주면 해당 id의 장학금 프로그램을 반환합니다.")
+    @GetMapping("/scholarship/{id}")
+    public ResponseEntity<ApiResponse<ScholarshipResponseDto>> getScholarship(@PathVariable int id) {
+        return ApiResponse.success(scholarshipService.findScholarship(id));
+    }
+
+    @Operation(summary = "조건 검색된 장학금 프로그램 목록 조회", description = "키워드(keyword)와 정렬 방식(sort), 필터 조건(amount, status)으로 장학금 프로그램을 검색하며, 페이징 처리를 진행하여 데이터 목록을 반환합니다.\n" +
+            "정렬 방식(sort)에는 [마감일순, 금액순, 인기순] 세가지가 있으며, 기본값은 마감일순입니다.\n" +
+            "필터 조건(amount)에는 [5미만, 5~10, 10이상] 세가지가 있으며 기본값은 전체 표시입니다. 필터 조건(status)에는 [진행중, 마감임박, 마감] 세가지가 있으며 기본값은 전체 표시입니다. 마감임박일 때에는 limit를 통해 임박 기준을 정할 수 있으며 기본값은 4일입니다.")
+    @GetMapping("/scholarship")
+    public ResponseEntity<ApiResponse<PageResponseDto<ScholarshipResponseDto>>> getScholarshipList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "deadline") String sort,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String amount,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) int limit
+    ) {
+        PageResponseDto<ScholarshipResponseDto> response = scholarshipService.findScholarships(page, size, sort, keyword, amount, status, limit);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "단일 교내외 프로그램 조회", description = "클라이언트가 조회할 데이터를 {id}로 구분해서 요청해주면 해당 id의 교내외 프로그램을 반환합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ProgramResponseDto>> getProgram(@PathVariable int id) {
+        return ApiResponse.success(programService.findProgram(id));
+    }
+
+    @Operation(summary = "조건 검색된 교내외 프로그램 목록 조회", description = "키워드(keyword)와 정렬 방식(sort), 필터 조건(category, mode, tag)으로 교내외 프로그램을 검색하며, 페이징 처리를 진행하여 데이터 목록을 반환합니다.\n" +
+            "정렬 방식(sort)에는 마감임박순, 최신순, 인기순 세가지가 있으며, 기본값은 마감임박순입니다.\n" +
+            "필터 조건(category)에는 [학술, 취업, 문화, 봉사, 국제교류, 창업] 여섯가지가 있으며(다중 선택 가능) 기본값은 전체 표시입니다. 필터 조건(mode)에는 [오프라인, 온라인, 혼합] 세가지가 있으며(다중 선택 가능) 기본값은 전체 표시입니다." +
+            "필터 조건(tag)에는 [장학금, 인증서, 학점, 상금, 멘토링] 다섯가지가 있으며(다중 선택 가능) 기본값은 전체 표시입니다.")
+    @GetMapping("/general")
+    public ResponseEntity<ApiResponse<PageResponseDto<ProgramResponseDto>>> getProgramList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "applicationEnd") String sort,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) List<String> category,
+            @RequestParam(required = false) List<String> mode,
+            @RequestParam(required = false) List<String> tag
+    ) {
+        PageResponseDto<ProgramResponseDto> response = programService.findPrograms(page, size, sort, keyword, category, mode, tag);
+        return ApiResponse.success(response);
+    }
+
+}

--- a/src/main/java/com/ptip/program/dto/PageResponseDto.java
+++ b/src/main/java/com/ptip/program/dto/PageResponseDto.java
@@ -1,0 +1,19 @@
+package com.ptip.program.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PageResponseDto<T> {
+    private List<T> items;
+    private int totalPages;
+    private long totalElements;
+    private int currentPage;
+    private int pageSize;
+    private boolean isLast;
+}

--- a/src/main/java/com/ptip/program/dto/ProgramResponseDto.java
+++ b/src/main/java/com/ptip/program/dto/ProgramResponseDto.java
@@ -1,0 +1,45 @@
+package com.ptip.program.dto;
+
+import com.ptip.program.entity.Program;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ProgramResponseDto {
+
+    private int id;
+    private String title;
+    private String description;
+    private String category;
+    private String applicationStart;
+    private String applicationEnd;
+    private String programStart;
+    private String programEnd;
+    private String mode;
+    private String location;
+    private String tags;
+    private String howToApply;
+    private String applyUrl;
+    private Boolean liked;
+
+    public static ProgramResponseDto from(Program program) {
+        return ProgramResponseDto.builder()
+                .id(program.getId())
+                .title(program.getTitle())
+                .category(program.getCategory())
+                .description(program.getDescription())
+                .applicationStart(program.getApplicationStart() != null ? program.getApplicationStart().toString() : null)
+                .applicationEnd(program.getApplicationEnd() != null ? program.getApplicationEnd().toString() : null)
+                .programStart(program.getProgramStart() != null ? program.getProgramStart().toString() : null)
+                .programEnd(program.getProgramEnd() != null ? program.getProgramEnd().toString() : null)
+                .mode(program.getMode())
+                .location(program.getLocation())
+                .tags(program.getTags())
+                .applyUrl(program.getApplyUrl())
+                .howToApply(program.getHowToApply())
+                .build();
+    }
+}

--- a/src/main/java/com/ptip/program/dto/ScholarshipResponseDto.java
+++ b/src/main/java/com/ptip/program/dto/ScholarshipResponseDto.java
@@ -1,0 +1,42 @@
+package com.ptip.program.dto;
+
+import com.ptip.program.entity.Scholarship;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ScholarshipResponseDto {
+
+    private int id;
+    private String title;
+    private String description;
+    private String department;
+    private int minAmount;
+    private int maxAmount;
+    private String deadline;
+    private String eligibility;
+    private String requiredDocuments;
+    private String steps;
+    private String applyUrl;
+
+    public static ScholarshipResponseDto from(Scholarship scholarship) {
+        return ScholarshipResponseDto.builder()
+                .id(scholarship.getId())
+                .title(scholarship.getTitle())
+                .description(scholarship.getDescription())
+                .department(scholarship.getDepartment())
+                .minAmount(scholarship.getMinAmount())
+                .maxAmount(scholarship.getMaxAmount())
+                .deadline(scholarship.getDeadline() != null ? scholarship.getDeadline().toString() : null)
+                .eligibility(scholarship.getEligibility())
+                .requiredDocuments(scholarship.getRequiredDocuments())
+                .steps(scholarship.getSteps())
+                .applyUrl(scholarship.getApplyUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/ptip/program/dto/ScholarshipResponseDto.java
+++ b/src/main/java/com/ptip/program/dto/ScholarshipResponseDto.java
@@ -23,6 +23,7 @@ public class ScholarshipResponseDto {
     private String requiredDocuments;
     private String steps;
     private String applyUrl;
+    private Boolean liked;
 
     public static ScholarshipResponseDto from(Scholarship scholarship) {
         return ScholarshipResponseDto.builder()

--- a/src/main/java/com/ptip/program/entity/Program.java
+++ b/src/main/java/com/ptip/program/entity/Program.java
@@ -1,0 +1,49 @@
+package com.ptip.program.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "programs")
+public class Program {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String title;
+
+    private String category;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "application_start", nullable = false)
+    private LocalDate applicationStart;
+
+    @Column(name = "application_end", nullable = false)
+    private LocalDate applicationEnd;
+
+    @Column(name = "program_start", nullable = false)
+    private LocalDate programStart;
+
+    @Column(name = "program_end", nullable = false)
+    private LocalDate programEnd;
+
+    private String mode;
+
+    private String location;
+
+    private String tags;
+
+    @Column(name = "how_to_apply", nullable = false)
+    private String howToApply;
+
+    @Column(name = "apply_url", nullable = false)
+    private String applyUrl;
+
+    private int popularity;
+}

--- a/src/main/java/com/ptip/program/entity/Scholarship.java
+++ b/src/main/java/com/ptip/program/entity/Scholarship.java
@@ -1,0 +1,43 @@
+package com.ptip.program.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "scholarships")
+public class Scholarship {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    private String department;
+
+    @Column(name = "min_amount", nullable = false)
+    private int minAmount;
+
+    @Column(name = "max_amount", nullable = false)
+    private int maxAmount;
+
+    private LocalDate deadline;
+
+    private String eligibility;
+
+    @Column(name = "required_documents", nullable = false)
+    private String requiredDocuments;
+
+    private String steps;
+
+    @Column(name = "apply_url", nullable = false)
+    private String applyUrl;
+
+    private int popularity;
+}

--- a/src/main/java/com/ptip/program/repository/ProgramRepository.java
+++ b/src/main/java/com/ptip/program/repository/ProgramRepository.java
@@ -1,0 +1,9 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Program;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProgramRepository extends JpaRepository<Program, Integer> {
+}

--- a/src/main/java/com/ptip/program/repository/ProgramRepositoryCustom.java
+++ b/src/main/java/com/ptip/program/repository/ProgramRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Program;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProgramRepositoryCustom {
+    Page<Program> getPrograms(String keyword, List<String> categories, List<String> modes, List<String> tags, Pageable pageable);
+}

--- a/src/main/java/com/ptip/program/repository/ProgramRepositoryImpl.java
+++ b/src/main/java/com/ptip/program/repository/ProgramRepositoryImpl.java
@@ -1,0 +1,94 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Program;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ptip.program.entity.QProgram.program;
+
+public class ProgramRepositoryImpl implements ProgramRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public ProgramRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<Program> getPrograms(String keyword, List<String> categories, List<String> modes, List<String> tags, Pageable pageable) {
+        JPAQuery<Program> programQuery = jpaQueryFactory
+                .selectFrom(program)
+                .where(containsKeyword(keyword), categoryIn(categories), modeIn(modes), tagIn(tags))
+                .orderBy(getOrderSpecifiers(pageable.getSort()).toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<Program> programs = programQuery.fetch();
+
+        JPAQuery<Long> programCountQuery = jpaQueryFactory
+                .select(program.count())
+                .from(program)
+                .where(containsKeyword(keyword), categoryIn(categories), modeIn(modes), tagIn(tags));
+
+        return PageableExecutionUtils.getPage(programs, pageable, programCountQuery::fetchOne);
+    }
+
+    private BooleanExpression containsKeyword(String keyword) {
+        return StringUtils.hasText(keyword) ? program.title.contains(keyword).or(program.description.contains(keyword)) : null;
+    }
+
+    private BooleanExpression categoryIn(List<String> categories) {
+        if (categories == null || categories.isEmpty()) return null;
+        return program.category.in(categories);
+    }
+
+    private BooleanExpression modeIn(List<String> modes) {
+        if (modes == null || modes.isEmpty()) return null;
+        return program.mode.in(modes);
+    }
+
+    private BooleanExpression tagIn(List<String> tags) {
+        if (tags == null || tags.isEmpty()) return null;
+
+        BooleanExpression predicate = null;
+        for (String tag : tags) {
+            BooleanExpression expr = program.tags.contains(tag);
+            predicate = (predicate == null) ? expr : predicate.or(expr);
+        }
+        return predicate;
+    }
+
+    private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            switch (order.getProperty()) {
+                case "최신순" -> orders.add(program.applicationEnd.desc());
+                case "인기순" -> orders.add(program.popularity.desc());
+                case "마감임박순" -> {
+                    LocalDate now = LocalDate.now();
+                    orders.add(new CaseBuilder()
+                            .when(program.applicationEnd.goe(now)).then(0)
+                            .when(program.applicationEnd.isNull()).then(1)
+                            .otherwise(2)
+                            .asc());
+                    orders.add(program.applicationEnd.asc());
+                }
+                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. " + order.getProperty());
+            }
+        }
+        return orders;
+    }
+}

--- a/src/main/java/com/ptip/program/repository/ProgramRepositoryImpl.java
+++ b/src/main/java/com/ptip/program/repository/ProgramRepositoryImpl.java
@@ -86,7 +86,7 @@ public class ProgramRepositoryImpl implements ProgramRepositoryCustom {
                             .asc());
                     orders.add(program.applicationEnd.asc());
                 }
-                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. " + order.getProperty());
+                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. sort=" + order.getProperty());
             }
         }
         return orders;

--- a/src/main/java/com/ptip/program/repository/ScholarshipRepository.java
+++ b/src/main/java/com/ptip/program/repository/ScholarshipRepository.java
@@ -1,0 +1,9 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Scholarship;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScholarshipRepository extends JpaRepository<Scholarship, Integer> {
+}

--- a/src/main/java/com/ptip/program/repository/ScholarshipRepositoryCustom.java
+++ b/src/main/java/com/ptip/program/repository/ScholarshipRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Scholarship;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScholarshipRepositoryCustom {
+    Page<Scholarship> getScholarships(String query, String amount, String status, int limit, Pageable pageable);
+}

--- a/src/main/java/com/ptip/program/repository/ScholarshipRepositoryImpl.java
+++ b/src/main/java/com/ptip/program/repository/ScholarshipRepositoryImpl.java
@@ -56,7 +56,7 @@ public class ScholarshipRepositoryImpl implements ScholarshipRepositoryCustom {
             case "5미만" -> scholarship.maxAmount.lt(50_000);
             case "5~10" -> scholarship.maxAmount.between(50_000, 100_000);
             case "10이상" -> scholarship.maxAmount.gt(100_000);
-            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. " + amount);
+            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. amount=" + amount);
         };
     }
 
@@ -66,9 +66,9 @@ public class ScholarshipRepositoryImpl implements ScholarshipRepositoryCustom {
         if (status == null) return null;
         return switch (status) {
             case "진행중" -> scholarship.deadline.goe(now);
-            case "마감임박" -> scholarship.deadline.between(now, now.plusDays(limit != 0 ? limit : 4));
+            case "마감임박" -> scholarship.deadline.between(now, now.plusDays(limit));
             case "마감" -> scholarship.deadline.lt(now);
-            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. " + status);
+            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. status=" + status);
         };
     }
 
@@ -88,7 +88,7 @@ public class ScholarshipRepositoryImpl implements ScholarshipRepositoryCustom {
                             .asc());
                     orders.add(scholarship.deadline.asc());
                 }
-                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. " + order.getProperty());
+                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. sort=" + order.getProperty());
             }
         }
         return orders;

--- a/src/main/java/com/ptip/program/repository/ScholarshipRepositoryImpl.java
+++ b/src/main/java/com/ptip/program/repository/ScholarshipRepositoryImpl.java
@@ -1,0 +1,96 @@
+package com.ptip.program.repository;
+
+import com.ptip.program.entity.Scholarship;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ptip.program.entity.QScholarship.scholarship;
+
+public class ScholarshipRepositoryImpl implements ScholarshipRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public ScholarshipRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<Scholarship> getScholarships(String keyword, String amount, String status, int limit, Pageable pageable) {
+        JPAQuery<Scholarship> scholarshipQuery = jpaQueryFactory
+                .selectFrom(scholarship)
+                .where(containsKeyword(keyword), amountCondition(amount), statusCondition(status, limit))
+                .orderBy(getOrderSpecifiers(pageable.getSort()).toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset()) // 페이지 시작 위치
+                .limit(pageable.getPageSize()); // 페이지 크기
+
+        List<Scholarship> scholarships = scholarshipQuery.fetch();
+
+        JPAQuery<Long> scholarshipCountQuery = jpaQueryFactory
+                .select(scholarship.count())
+                .from(scholarship)
+                .where(containsKeyword(keyword), amountCondition(amount), statusCondition(status, limit));
+
+        return PageableExecutionUtils.getPage(scholarships, pageable, scholarshipCountQuery::fetchOne);
+    }
+
+    private BooleanExpression containsKeyword(String query) {
+        return StringUtils.hasText(query) ? scholarship.title.contains(query).or(scholarship.description.contains(query)) : null;
+    }
+
+    private BooleanExpression amountCondition(String amount) {
+        if (amount == null) return null;
+
+        return switch (amount) {
+            case "5미만" -> scholarship.maxAmount.lt(50_000);
+            case "5~10" -> scholarship.maxAmount.between(50_000, 100_000);
+            case "10이상" -> scholarship.maxAmount.gt(100_000);
+            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. " + amount);
+        };
+    }
+
+    private BooleanExpression statusCondition(String status, int limit) {
+        LocalDate now = LocalDate.now();
+
+        if (status == null) return null;
+        return switch (status) {
+            case "진행중" -> scholarship.deadline.goe(now);
+            case "마감임박" -> scholarship.deadline.between(now, now.plusDays(limit != 0 ? limit : 4));
+            case "마감" -> scholarship.deadline.lt(now);
+            default -> throw new IllegalArgumentException("지원하지 않는 조건 필드입니다. " + status);
+        };
+    }
+
+    private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            switch (order.getProperty()) {
+                case "금액순" -> orders.add(scholarship.maxAmount.asc());
+                case "인기순" -> orders.add(scholarship.popularity.desc());
+                case "마감일순" -> {
+                    LocalDate now = LocalDate.now();
+                    orders.add(new CaseBuilder()
+                            .when(scholarship.deadline.goe(now)).then(0)
+                            .when(scholarship.deadline.isNull()).then(1)
+                            .otherwise(2)
+                            .asc());
+                    orders.add(scholarship.deadline.asc());
+                }
+                default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다. " + order.getProperty());
+            }
+        }
+        return orders;
+    }
+}

--- a/src/main/java/com/ptip/program/service/ProgramService.java
+++ b/src/main/java/com/ptip/program/service/ProgramService.java
@@ -1,0 +1,52 @@
+package com.ptip.program.service;
+
+import com.ptip.common.exception.ResourceNotFoundException;
+import com.ptip.program.dto.PageResponseDto;
+import com.ptip.program.dto.ProgramResponseDto;
+import com.ptip.program.entity.Program;
+import com.ptip.program.repository.ProgramRepository;
+import com.ptip.program.repository.ProgramRepositoryCustom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ProgramService {
+
+    private final ProgramRepository programRepository;
+    private final ProgramRepositoryCustom programRepositoryCustom;
+
+    public ProgramService(ProgramRepository programRepository, ProgramRepositoryCustom programRepositoryCustom) {
+        this.programRepository = programRepository;
+        this.programRepositoryCustom = programRepositoryCustom;
+    }
+
+    public ProgramResponseDto findProgram(int id) {
+        Program program = programRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("해당 id의 프로그램을 찾을 수 없습니다."));
+
+        return ProgramResponseDto.from(program);
+    }
+
+    public PageResponseDto<ProgramResponseDto> findPrograms(int page, int size, String sort, String keyword, List<String> categories, List<String> modes, List<String> tags) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort).ascending());
+        Page<Program> result = programRepositoryCustom.getPrograms(keyword, categories, modes, tags, pageable);
+
+        List<ProgramResponseDto> items = result.getContent().stream()
+                .map(ProgramResponseDto::from)
+                .collect(Collectors.toList());
+
+        return PageResponseDto.<ProgramResponseDto>builder()
+                .items(items)
+                .totalPages(result.getTotalPages())
+                .totalElements(result.getTotalElements())
+                .currentPage(result.getNumber())
+                .pageSize(result.getSize())
+                .isLast(result.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/ptip/program/service/ScholarshipService.java
+++ b/src/main/java/com/ptip/program/service/ScholarshipService.java
@@ -1,0 +1,52 @@
+package com.ptip.program.service;
+
+import com.ptip.common.exception.ResourceNotFoundException;
+import com.ptip.program.dto.PageResponseDto;
+import com.ptip.program.dto.ScholarshipResponseDto;
+import com.ptip.program.entity.Scholarship;
+import com.ptip.program.repository.ScholarshipRepository;
+import com.ptip.program.repository.ScholarshipRepositoryCustom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ScholarshipService {
+
+    private final ScholarshipRepository scholarshipRepository;
+    private final ScholarshipRepositoryCustom scholarshipRepositoryCustom;
+
+    public ScholarshipService(ScholarshipRepository scholarshipRepository, ScholarshipRepositoryCustom scholarshipRepositoryCustom) {
+        this.scholarshipRepository = scholarshipRepository;
+        this.scholarshipRepositoryCustom = scholarshipRepositoryCustom;
+    }
+
+    public ScholarshipResponseDto findScholarship(int id) {
+        Scholarship scholarship = scholarshipRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("해당 id의 장학금 프로그램을 찾을 수 없습니다."));
+
+        return ScholarshipResponseDto.from(scholarship);
+    }
+
+    public PageResponseDto<ScholarshipResponseDto> findScholarships(int page, int size, String sort, String keyword, String amount, String status, int limit) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort).ascending());
+        Page<Scholarship> result = scholarshipRepositoryCustom.getScholarships(keyword, amount, status, limit, pageable);
+
+        List<ScholarshipResponseDto> items = result.getContent().stream()
+                .map(ScholarshipResponseDto::from)
+                .collect(Collectors.toList());
+
+        return PageResponseDto.<ScholarshipResponseDto>builder()
+                .items(items)
+                .totalPages(result.getTotalPages())
+                .totalElements(result.getTotalElements())
+                .currentPage(result.getNumber())
+                .pageSize(result.getSize())
+                .isLast(result.isLast())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

장학금/교내외 프로그램 조회 기능(API 4종)을 추가했습니다.  
id별 장학금 혹은 교내외 프로그램을 조회할 수 있습니다.
여러 프로그램을 필터 검색과 정렬 처리하여 조회할 수 있습니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).