### PR TITLE
[feat]: 이메일 인증 기능 추가 및 Gmail SMTP 설정 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
 }
 
 tasks.named('test') {

--- a/generate-properties.sh
+++ b/generate-properties.sh
@@ -37,6 +37,9 @@ springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.disable-swagger-default-url=true
 
 server.forward-headers-strategy=framework
+
+spring.mail.username=ptip.sender@gmail.com
+spring.mail.password=vuvcunkndgloficd
 EOF
 
 echo "✅ application-prod.properties 생성 완료!"

--- a/src/main/java/com/ptip/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ptip/auth/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/auth/**", "/api-docs/**", "/swagger", "/swagger-ui/**", "/api/programs/**").permitAll()
+                        .requestMatchers("/", "/auth/**", "/api-docs/**", "/swagger", "/swagger-ui/**", "/api/programs/**",
+                                "/email/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ptip/auth/email/controller/SchoolEmailVerificationController.java
+++ b/src/main/java/com/ptip/auth/email/controller/SchoolEmailVerificationController.java
@@ -1,0 +1,67 @@
+package com.ptip.auth.email.controller;
+
+import com.ptip.auth.email.dto.SchoolEmailRequestDto;
+import com.ptip.auth.email.dto.SchoolEmailVerifyDto;
+import com.ptip.auth.email.service.SchoolEmailVerificationService;
+import com.ptip.auth.entity.User;
+import com.ptip.auth.jwt.JwtUtil;
+import com.ptip.auth.repository.UserRepository;
+import com.ptip.common.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class SchoolEmailVerificationController {
+
+    private final SchoolEmailVerificationService emailService;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    private User getUserFromRequest(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer == null || !bearer.startsWith("Bearer ")) {
+            throw new RuntimeException("JWT 토큰이 없습니다.");
+        }
+        String token = bearer.substring(7);
+        int userId = Integer.parseInt(jwtUtil.extractUserId(token));
+        return userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자 없음"));
+    }
+
+    /**
+     * 인증번호 전송
+     */
+    @PostMapping("/send")
+    public ResponseEntity<?> send(@RequestBody SchoolEmailRequestDto dto, HttpServletRequest request) {
+        User user = getUserFromRequest(request);
+        emailService.sendSchoolEmail(dto.getSchoolEmail(), user);
+        return ApiResponse.success("학교 인증번호가 전송되었습니다.");
+    }
+
+    /**
+     * 인증번호 검증
+     */
+    @PostMapping("/verify")
+    public ResponseEntity<?> verify(@RequestBody SchoolEmailVerifyDto dto, HttpServletRequest request) {
+        User user = getUserFromRequest(request);
+        boolean result = emailService.verifySchoolEmail(dto.getSchoolEmail(), dto.getCode(), user);
+        if (result) {
+            return ApiResponse.success("학교 이메일 인증 완료");
+        } else {
+            return ApiResponse.error(HttpStatus.UNAUTHORIZED, "인증 실패");
+        }
+    }
+
+    /**
+     * 인증 여부 확인
+     */
+    @GetMapping("/check")
+    public ResponseEntity<?> check(HttpServletRequest request) {
+        User user = getUserFromRequest(request);
+        return ApiResponse.success(emailService.isSchoolEmailVerified(user));   // ture / false
+    }
+}

--- a/src/main/java/com/ptip/auth/email/dto/SchoolEmailRequestDto.java
+++ b/src/main/java/com/ptip/auth/email/dto/SchoolEmailRequestDto.java
@@ -1,0 +1,8 @@
+package com.ptip.auth.email.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SchoolEmailRequestDto {
+    private String schoolEmail;
+}

--- a/src/main/java/com/ptip/auth/email/dto/SchoolEmailVerifyDto.java
+++ b/src/main/java/com/ptip/auth/email/dto/SchoolEmailVerifyDto.java
@@ -1,0 +1,9 @@
+package com.ptip.auth.email.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SchoolEmailVerifyDto {
+    private String schoolEmail;
+    private String code;
+}

--- a/src/main/java/com/ptip/auth/email/service/SchoolEmailVerificationService.java
+++ b/src/main/java/com/ptip/auth/email/service/SchoolEmailVerificationService.java
@@ -1,0 +1,93 @@
+package com.ptip.auth.email.service;
+
+import com.ptip.auth.entity.User;
+import com.ptip.auth.repository.UserRepository;
+import jakarta.mail.*;
+import jakarta.mail.internet.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Properties;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class SchoolEmailVerificationService {
+
+    private final UserRepository userRepository;
+
+    @Value("${spring.mail.username}")
+    private String sender;  // 메일 발신 주소
+
+    @Value("${spring.mail.password}")
+    private String password;  // 앱 비밀번호 (Gmail/학교 SMTP)
+
+    /**
+     * 학교 이메일 인증번호 전송
+     */
+    public void sendSchoolEmail(String schoolEmail, User user) {
+        if (!schoolEmail.endsWith("@ptu.ac.kr")) {
+            throw new IllegalArgumentException("학교 이메일(@ptu.ac.kr)만 인증 가능합니다.");
+        }
+
+        String code = generateCode();
+        user.setSchoolEmail(schoolEmail);
+        user.setSchoolEmailVerified(false);
+        user.setSchoolEmailVerificationCode(code);
+        userRepository.save(user);
+
+        sendEmail(schoolEmail, code);
+    }
+
+    /**
+     * 학교 이메일 인증번호 검증
+     */
+    public boolean verifySchoolEmail(String email, String code, User user) {
+        if (email.equals(user.getSchoolEmail()) && code.equals(user.getSchoolEmailVerificationCode())) {
+            user.setSchoolEmailVerified(true);
+            user.setSchoolEmailVerificationCode(null);
+            userRepository.save(user);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 학교 이메일 인증 여부 조회
+     */
+    public boolean isSchoolEmailVerified(User user) {
+        return user.isSchoolEmailVerified();
+    }
+
+    private String generateCode() {
+        return String.valueOf(new Random().nextInt(900000) + 100000); // 6자리 숫자
+    }
+
+    private void sendEmail(String to, String code) {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", "smtp.gmail.com"); // 학교 SMTP 사용 시 변경 가능
+        props.put("mail.smtp.port", "587");
+        props.put("mail.smtp.ssl.trust", "smtp.gmail.com");
+        props.put("mail.smtp.ssl.protocols", "TLSv1.2");
+
+        Session session = Session.getInstance(props, new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(sender, password);
+            }
+        });
+
+        try {
+            Message message = new MimeMessage(session);
+            message.setFrom(new InternetAddress(sender));
+            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(to));
+            message.setSubject("[PTIP 인증] 학교 이메일 인증번호");
+            message.setText("아래 인증번호를 입력해주세요\n\n" + code);
+            Transport.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 전송 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ptip/auth/entity/User.java
+++ b/src/main/java/com/ptip/auth/entity/User.java
@@ -28,4 +28,13 @@ public class User {
     private String email;
 
     private String refreshToken;
+
+    @Column
+    private String schoolEmail;
+
+    @Column(nullable = false)
+    private boolean schoolEmailVerified = false;
+
+    @Column
+    private String schoolEmailVerificationCode;
 }

--- a/src/main/java/com/ptip/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/ptip/auth/jwt/JwtUtil.java
@@ -39,4 +39,11 @@ public class JwtUtil {
                 .withExpiresAt(new Date(System.currentTimeMillis() + refreshTokenExpiration))
                 .sign(Algorithm.HMAC256(secretKey));
     }
+
+    public String extractUserId(String token) {
+        return JWT.require(Algorithm.HMAC256(secretKey))
+                .build()
+                .verify(token)
+                .getClaim("userId").asString();
+    }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

학교 이메일 인증 기능을 새롭게 추가하였으며, Gmail SMTP 기반의 인증 메일 전송 기능을 구현했습니다.
사용자가 로그인 후 자신의 학교 이메일(@ptu.ac.kr)을 등록하면, 인증번호가 해당 이메일로 전송되며 인증 여부를 확인할 수 있습니다.

---

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

* [x] 새로운 기능 추가
* [x] DB 컬럼 추가 (`schoolEmail`, `schoolEmailVerified`, `schoolEmailVerificationCode`)
* [x] 이메일 인증 API 추가
* [x] Gmail SMTP 설정 및 예외 처리 적용
* [x] 코드 리팩토링 및 주석 보완

### 🔑 주요 구현 기능

#### ✅ 1. 학교 이메일 인증 API 추가

* `/email/school/send`: 학교 이메일로 인증번호 전송
* `/email/school/verify`: 인증번호 확인
* `/email/school/check`: 인증 완료 여부 확인
* 이메일 도메인 제한: `@ptu.ac.kr`만 허용

#### ✅ 2. 사용자 엔티티 컬럼 추가

* `schoolEmail`: 사용자 학교 이메일 주소
* `schoolEmailVerified`: 인증 여부(boolean)
* `schoolEmailVerificationCode`: 발송된 인증번호

#### ✅ 3. Gmail SMTP 메일 전송 기능 구현

* `javax.mail` 기반 SMTP 설정
* TLS 1.2 기반 Gmail 전송 설정 적용
* 인증번호 6자리 생성 및 메일 본문 삽입
* SMTP 인증 오류 및 TLS handshake 예외 처리 추가

---

## 💬 공유사항 to 리뷰어

* 이메일 인증 기능은 로그인된 사용자 기준으로 작동하며, accessToken 기반 인증 헤더가 필요합니다.
* `@ptu.ac.kr` 도메인만 허용되며, 이를 벗어날 경우 400 오류가 발생합니다.
* 이메일 전송은 Gmail 앱 비밀번호를 사용해야 하며, TLS 설정에 따라 `mail.smtp.ssl.protocols=TLSv1.2`를 반드시 포함해야 정상 작동합니다.
* 인증번호 재전송 시 기존 코드가 갱신되며, 검증도 새로운 코드 기준으로 수행됩니다.

---

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
* [x] 기능 동작 확인 및 테스트를 완료했습니다.
* [x] Swagger 문서에서 API 테스트가 가능함을 확인했습니다.